### PR TITLE
Added instructions to run OpenEBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,29 @@ $ kubectl apply -f https://raw.githubusercontent.com/rook/rook/master/cluster/ex
 $ kubectl patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
 ```
+
+## [OpenEBS](https://github.com/openebs/openebs)
+
+```bash
+# OpenEBS can be setup in few easy steps. 
+# You can get going on your choice of Kubernetes cluster by having open-iscsi installed on the Kubernetes nodes and running the openebs-operator using kubectl.
+
+# Start the OpenEBS Services using Operator:
+$ kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+
+# As an alternative to the above comment you can also use Helm to install OpenEBS if you like [stable/openebs](https://github.com/kubernetes/charts/tree/master/stable/openebs):
+$ helm install stable/openebs
+
+# Customize or use the Default storageclasses
+$ kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+
+# List predefined OpenEBS Storage Classes
+$ kubectl get sc
+
+# set openEBS Standard Storage Class as default storageclass 
+$ kubectl patch storageclass openebs-standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+# Optional: Enable monitoring using Prometheus and Grafana
+$ kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-monitoring-pg.yaml
+
+```

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ $ kubectl patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"s
 # Start the OpenEBS Services using Operator:
 $ kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
 
-# As an alternative to the above comment you can also use Helm to install OpenEBS if you like [stable/openebs](https://github.com/kubernetes/charts/tree/master/stable/openebs):
+# As an alternative to the above comment you can also use Helm package manager to install OpenEBS. 
+# More info on OpenEBS Chart: https://github.com/kubernetes/charts/tree/master/stable/openebs
 $ helm install stable/openebs
 
 # Customize or use the Default storageclasses


### PR DESCRIPTION
Instructions include the following:

- Installing the OpenEBS Services using Operator
- Alternative installation using Helm package manager
- Adding predefined Storage Classes
- Listing predefined Storage Classes
- Setting OpenEBS Standard Storage Class as default storageclass
- Enabling monitoring using Prometheus and Grafana